### PR TITLE
Set SystemCount=0 to correct error in count

### DIFF
--- a/Get-RomHashes.ps1
+++ b/Get-RomHashes.ps1
@@ -135,7 +135,7 @@ $RASystems = Get-RASystemsList
 
 $HashOutputObject = [System.Collections.Generic.List[Object]]::New()
 
-$SystemCount = 1
+$SystemCount = 0
 Foreach ($System in $Systems) {
     $SystemCount++
     $PercentCompleteSystems = [Math]::Min(100, [int](($SystemCount / $Systems.Count) * 100))


### PR DESCRIPTION
Previously the SystemCount was initialized = 1 and then immediately incremented, causing an incorrect value. Setting the SystemCount = 0 prior to the first loop corrects this.